### PR TITLE
Add forge lint config, CI workflow, and CodeRabbit review config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+language: en-US
+
+reviews:
+  profile: chill
+  auto_review:
+    enabled: true
+    drafts: false
+  path_filters:
+    - "!lib/**"
+    - "!vendor/**"
+    - "!out/**"
+    - "!cache/**"
+    - "!broadcast/**"
+    - "!audits/**"
+  path_instructions:
+    - path: "src/**/*.sol"
+      instructions: >
+        This is audited Solidity contract code for a live orderbook/vault protocol.
+        Prioritize: reentrancy, access control (roles/ownership), unchecked external
+        calls, integer overflow/precision loss in fee and settlement math, signature
+        replay (EIP-712/EIP-1271), and any change to custody or withdrawal logic.
+        Flag any behavioral change to already-audited contracts, not just style.
+    - path: "script/**/*.sol"
+      instructions: >
+        These are deployment scripts. Focus on deployment safety: correct
+        constructor/initializer args, role assignment order, and any place a
+        misconfiguration could leave the deployed system in an insecure or
+        ungoverned state (e.g. admin roles not renounced/transferred correctly).
+    - path: "test/**/*.sol"
+      instructions: >
+        Focus on test coverage and assertion quality: are both success and
+        revert paths asserted, are edge cases (zero amounts, max values,
+        expired signatures) covered, and do fuzz/invariant tests have
+        meaningful bounds rather than trivially-passing ranges.
+
+chat:
+  auto_reply: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [audit]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Check formatting
+        run: forge fmt --check
+
+      - name: Lint
+        run: forge lint
+
+      - name: Build
+        run: forge build
+
+      - name: Test
+        run: forge test -vvv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+    branches: ['*']
   push:
     branches: [audit]
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -52,6 +52,9 @@ override_spacing = false
 wrap_comments = false
 ignore = []
 
+[lint]
+severity = ["high", "med", "low"]
+
 [rpc_endpoints]
 arbitrum_sepolia = "${ARBITRUM_SEPOLIA_RPC_URL}"
 sepolia = "${SEPOLIA_RPC_URL}"


### PR DESCRIPTION
## Summary
- Add `[lint]` section to `foundry.toml` (severity filtered to high/med/low, drops ~900 info-level style notes so `forge lint` output stays signal over noise)
- Add `.github/workflows/ci.yml` running `forge fmt --check` → `forge lint` → `forge build` → `forge test` on PRs and pushes to `audit` — this repo had no CI at all before this PR
- Add `.coderabbit.yaml` with Solidity-aware per-directory review instructions (security-focused for `src/`, deployment-safety-focused for `script/`, coverage-focused for `test/`) and vendor/build-artifact path filters

## Known issue surfaced by this PR
`forge fmt --check` currently fails against 35 existing files (4 in `src/`, 2 in `script/`, 29 in `test/`) that predate this PR and don't match the existing `foundry.toml [fmt]` rules. This PR intentionally does **not** reformat them — `src/` contains audited contracts, and reformatting was left out of scope by design. Because `forge fmt --check` is the first CI step and is not suppressed, **the "Check formatting" job will show red on this PR**, and the later `lint`/`build`/`test` steps in the same job will not run (GitHub Actions stops a job at its first failing step) until a follow-up PR runs `forge fmt` on those files. `forge lint`, `forge build`, and `forge test` all pass locally (verified below) — they're just not visible in the Actions UI yet because of step ordering.

## Test plan
- [x] `forge lint` passes locally (exit 0, only the intentional high/med/low-severity warnings show)
- [x] `forge build` passes locally
- [x] `forge test -vvv` passes locally (335/335 tests)
- [ ] CI runs on this PR (expected: fmt check red per above; lint/build/test not yet visible due to step ordering — tracked as follow-up)